### PR TITLE
feat: Add reminder functionality

### DIFF
--- a/commands/remindme.js
+++ b/commands/remindme.js
@@ -1,0 +1,151 @@
+import { SlashCommandBuilder, MessageFlags } from 'discord.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+const TIME_LIMITS = {
+    minutes: 1440, // 24 hours
+    hours: 168,    // 1 week
+    days: 365,     // 1 year
+    weeks: 52      // 1 year
+};
+
+const REMINDERS_FILE = path.join(process.cwd(), 'reminders.json');
+
+// Load reminders from file
+async function loadReminders() {
+    try {
+        const data = await fs.readFile(REMINDERS_FILE, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return [];
+        }
+        console.error('Error loading reminders:', error);
+        return [];
+    }
+}
+
+// Save reminders to file
+async function saveReminders(reminders) {
+    try {
+        await fs.writeFile(REMINDERS_FILE, JSON.stringify(reminders, null, 2));
+    } catch (error) {
+        console.error('Error saving reminders:', error);
+    }
+}
+
+// Add reminder
+async function addReminder(reminder) {
+    const reminders = await loadReminders();
+    reminders.push(reminder);
+    await saveReminders(reminders);
+}
+
+// Remove reminder
+async function removeReminder(reminderId) {
+    const reminders = await loadReminders();
+    const filtered = reminders.filter(r => r.id !== reminderId);
+    await saveReminders(filtered);
+}
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('remindme')
+        .setDescription('Set a reminder.')
+        .addStringOption(option =>
+            option.setName('text')
+                .setDescription('What should I remind you about?')
+                .setRequired(true))
+        .addIntegerOption(option =>
+            option.setName('time')
+                .setDescription('Amount of time')
+                .setRequired(true)
+                .setMinValue(1))
+        .addStringOption(option =>
+            option.setName('unit')
+                .setDescription('Minutes, hours, days, or weeks?')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Minutes', value: 'minutes' },
+                    { name: 'Hours', value: 'hours' },
+                    { name: 'Days', value: 'days' },
+                    { name: 'Weeks', value: 'weeks' }
+                )),
+    async execute(interaction) {
+        try {
+            const timeAmount = interaction.options.getInteger('time');
+            const timeUnit = interaction.options.getString('unit');
+            const userId = interaction.user.id;
+            const channel = interaction.channel;
+            const text = interaction.options.getString('text');
+
+            // Check bot permissions
+            if (!channel.permissionsFor(channel.guild.members.me).has('ViewChannel') || 
+                !channel.permissionsFor(channel.guild.members.me).has('SendMessages')) {
+                return await interaction.reply({
+                    content: '❌ I cannot send messages in this channel. Please check my permissions.',
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+
+            // Check time limits
+            if (timeAmount > TIME_LIMITS[timeUnit]) {
+                return await interaction.reply({
+                    content: `❌ You cannot set a reminder for more than ${TIME_LIMITS[timeUnit]} ${timeUnit}!`,
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+
+            // Calculate reminder time
+            const msMultiplier = {
+                minutes: 60 * 1000,
+                hours: 60 * 60 * 1000,
+                days: 24 * 60 * 60 * 1000,
+                weeks: 7 * 24 * 60 * 60 * 1000
+            };
+
+            const ms = timeAmount * msMultiplier[timeUnit];
+            const reminderTime = Date.now() + ms;
+            const reminderId = `${userId}_${reminderTime}`;
+
+            const reminder = {
+                id: reminderId,
+                text,
+                userId,
+                reminderTime,
+                channelId: interaction.channelId,
+                guildId: interaction.guildId
+            };
+
+            // Save reminder
+            await addReminder(reminder);
+
+            const timeString = `${timeAmount} ${timeUnit}`;
+            await interaction.reply({
+                content: `✅ I will remind you about "${text}" in ${timeString}`,
+                flags: MessageFlags.Ephemeral
+            });
+
+            // Set timeout for reminder
+            setTimeout(async () => {
+                try {
+                    const channel = await interaction.client.channels.fetch(reminder.channelId);
+                    await channel.send({
+                        content: `<@${userId}> 🔔 Reminder: ${text}`,
+                        allowedMentions: { users: [userId] },
+                    });
+                    await removeReminder(reminderId);
+                } catch (error) {
+                    console.error('Error sending reminder:', error);
+                    await removeReminder(reminderId);
+                }
+            }, ms);
+        } catch (error) {
+            console.error('Error setting reminder:', error);
+            await interaction.reply({
+                content: '❌ An error occurred while setting the reminder.',
+                flags: MessageFlags.Ephemeral
+            });
+        }
+    }
+};

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { Client, Collection, GatewayIntentBits, REST, Routes, MessageFlags } from 'discord.js';
+import { initializeReminders } from './reminderManager.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -38,6 +39,9 @@ const rest = new REST({ version: '10' }).setToken(TOKEN);
 
 client.once('ready', async () => {
   console.log(`✅ Bot is online as ${client.user.tag}`);
+
+  // Initialize reminder system
+  await initializeReminders(client);
 
   try {
     console.log('📥 Registering slash commands...');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "discord.js": "^14.21.0",
-        "dotenv": "^16.5.0"
+        "dotenv": "^16.5.0",
+        "node-cron": "^4.2.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
@@ -3947,6 +3948,15 @@
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-emoji": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "discord.js": "^14.21.0",
-    "dotenv": "^16.5.0"
+    "dotenv": "^16.5.0",
+    "node-cron": "^4.2.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/reminderManager.js
+++ b/reminderManager.js
@@ -1,0 +1,64 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const REMINDERS_FILE = path.join(process.cwd(), 'reminders.json');
+
+// Load and restore reminders on bot startup
+export async function initializeReminders(client) {
+    try {
+        const data = await fs.readFile(REMINDERS_FILE, 'utf8');
+        const reminders = JSON.parse(data);
+        
+        const activeReminders = [];
+        const now = Date.now();
+        
+        for (const reminder of reminders) {
+            const timeLeft = reminder.reminderTime - now;
+            
+            if (timeLeft > 0) {
+                // Reminder is still pending, reschedule it
+                setTimeout(async () => {
+                    try {
+                        const channel = await client.channels.fetch(reminder.channelId);
+                        await channel.send({
+                            content: `<@${reminder.userId}> 🔔 Reminder: ${reminder.text}`,
+                            allowedMentions: { users: [reminder.userId] },
+                        });
+                    } catch (error) {
+                        console.error('Error sending restored reminder:', error);
+                    }
+                    // Remove reminder after sending
+                    await removeReminder(reminder.id);
+                }, timeLeft);
+                
+                activeReminders.push(reminder);
+                console.log(`Restored reminder for user ${reminder.userId}: "${reminder.text}" (${Math.round(timeLeft / 1000 / 60)} minutes left)`);
+            }
+        }
+        
+        // Save only active reminders back to file
+        await fs.writeFile(REMINDERS_FILE, JSON.stringify(activeReminders, null, 2));
+        
+        console.log(`Restored ${activeReminders.length} active reminders`);
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            // File doesn't exist, create empty file
+            await fs.writeFile(REMINDERS_FILE, JSON.stringify([], null, 2));
+            console.log('Created new reminders file');
+        } else {
+            console.error('Error initializing reminders:', error);
+        }
+    }
+}
+
+// Helper function to remove reminder
+async function removeReminder(reminderId) {
+    try {
+        const data = await fs.readFile(REMINDERS_FILE, 'utf8');
+        const reminders = JSON.parse(data);
+        const filtered = reminders.filter(r => r.id !== reminderId);
+        await fs.writeFile(REMINDERS_FILE, JSON.stringify(filtered, null, 2));
+    } catch (error) {
+        console.error('Error removing reminder:', error);
+    }
+}


### PR DESCRIPTION
## What's Changed

- Added `/remindme` slash command for setting reminders
- Support for minutes, hours, days, and weeks time units
- Persistent reminder storage using JSON files
- Auto-restore reminders after bot restarts
- Time limits to prevent excessive reminders
- Added node-cron dependency for scheduling

## How it works

Users can set reminders with `/remindme text:"Meeting" time:30 unit:minutes`
The bot will mention them in the same channel when the time expires.

## Technical Details

- Reminders are stored in `reminders.json` for persistence
- Uses `setTimeout()` for scheduling
- Automatically restores pending reminders on bot startup
- Includes permission checks and error handling

## Credits

Shamelessly borrowed from my own [streamyfin-discord-bot](https://github.com/streamyfin/streamyfin-discord-bot) because why reinvent the wheel when you can ctrl+c ctrl+v your own code? Redis was swapped out for good old JSON files.