### PR TITLE
fix: community warning

### DIFF
--- a/commands/piracy.js
+++ b/commands/piracy.js
@@ -4,8 +4,8 @@ import { SlashCommandBuilder } from 'discord.js';
 export default {
 	data: new SlashCommandBuilder()
 		.setName('piracy')
-		.setDescription('Policy on piracy discussions.'),
+		.setDescription('Policy on piracy and content acquisition.'),
 	async execute(interaction) {
-		await interaction.reply("🏴‍☠️ Discussions or content related to piracy or content acquisition are prohibited in this community. This rule exists to maintain a safe and respectful environment for all members, prevent legal issues or witch hunts, and protect the community’s integrity, credibility, and long-term stability");
+		await interaction.reply("**:warning: Community Warning**\n\nDiscussions of piracy, content acquisition, or related activities, including tools and outlets that enable them, are prohibited. [Rule 2](https://discord.com/channels/1381737066366242896/1381738925625970758) exists in order to ensure a safe, orderly, and legally compliant community.\n\n*Note: Occasional false triggers may occur. Disregard accordingly.*");
 	},
 };


### PR DESCRIPTION
Replaced the old command message with an updated, clearer warning. Includes multi-line formatting, Markdown styling, a link to Rule 2, and a note on occasional false triggers