### PR TITLE
fix: add required permissions to commitlint workflow

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds the required `issues: write` and `pull-requests: write` permissions to the commitlint workflow to resolve GitHub Actions permission issues.

The workflow needs these permissions to write comments on pull requests with lint results and update issue/PR status based on commit lint validation.